### PR TITLE
update AndroidManifest.xml to leverage Android 12 new Bluetooth permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.1
+* Upgraded Android Bluetooth Permissions
+
 ## 3.3.0
 * Upgraded Android Dependency to 1.12.1-beta01
 * Upgraded Android Gradle

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,9 +1,27 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="dev.steenbakker.nordicdfu">
 
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- required for API 18 - 30 -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+
+    <!-- required for API 23 - 30 -->
+    <uses-permission-sdk-23
+        android:name="android.permission.ACCESS_COARSE_LOCATION"
+        android:maxSdkVersion="30" />
+    <uses-permission-sdk-23
+        android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
+
+    <!-- API 31+ -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <!-- add android:usesPermissionFlags="neverForLocation" when you can strongly assert that
+         your app never derives physical location from Bluetooth scan results. -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
 
     <application>
         <service android:name=".DfuService" />

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nordic_dfu
 description: This library allows you to do a Device Firmware Update (DFU) of your nrf51 or nrf52 chip from Nordic Semiconductor. Fork of flutter-nordic-dfu.
-version: 3.3.0
+version: 3.3.1
 homepage: https://github.com/juliansteenbakker/nordic_dfu
 
 environment:


### PR DESCRIPTION
Hello there !
Thanks for keeping this pkg alive 😁

We faced an issue while trying to be Android 12 compliant regarding the Bluetooth permissions. So, along with some other changes, we forked this repo and updated the AndroidManifest.xml following same changes as seen in some other BLE package repository.
This pkg should now be Android 12 ready in terms of permission declaration 👍 


_PS: For people that depends on several libraries that declares Bluetooth permissions, you may have trouble with manifest merge conflicts and you should now that [`<uses-permission>`](https://developer.android.com/guide/topics/manifest/uses-permission-element) and [`<uses_permission-sdk-23>`](https://developer.android.com/guide/topics/manifest/uses-permission-sdk-23-element) have different behaviors. In our case, we had to override `<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>` and `<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>` on the root manifest to resolve some merge conflicts._