### PR TITLE
[FIX] Fix issue #45 - callback KO if other Foreground service

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfuPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfuPlugin.kt
@@ -37,7 +37,7 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler,  EventChannel.StreamHa
         eventChannel = EventChannel(binding.binaryMessenger, "dev.steenbakker.nordic_dfu/event")
         eventChannel!!.setStreamHandler(this)
 
-        DfuServiceListenerHelper.registerProgressListener(binding.applicationContext, mDfuProgressListener)
+        
     }
 
     override fun onDetachedFromEngine(binding: FlutterPluginBinding) {
@@ -55,6 +55,7 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler,  EventChannel.StreamHa
     }
 
     override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        DfuServiceListenerHelper.registerProgressListener(binding.applicationContext, mDfuProgressListener)
         this.sink = events
     }
 


### PR DESCRIPTION
When In the app another Foreground service was started. The Callback of the DFU were not working anymore. With this simple fix, they are now working in all conditions.