### PR TITLE
Fix for Issue #58 - Breaking Change in IOS lib

### DIFF
--- a/ios/Classes/SwiftNordicDfuPlugin.swift
+++ b/ios/Classes/SwiftNordicDfuPlugin.swift
@@ -103,10 +103,10 @@ public class SwiftNordicDfuPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
             return
         }
         
-        guard let firmware = DFUFirmware(urlToZipFile: URL(fileURLWithPath: filePath)) else {
-            result(FlutterError(code: "DFU_FIRMWARE_NOT_FOUND", message: "Could not dfu zip file", details: nil))
-            return
-        }
+        do{
+        let firmware = try DFUFirmware(urlToZipFile: URL(fileURLWithPath: filePath)) 
+            
+        
         
         let dfuInitiator = DFUServiceInitiator(queue: nil)
             .with(firmware: firmware);
@@ -130,6 +130,11 @@ public class SwiftNordicDfuPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
         deviceAddress = address
         
         dfuController = dfuInitiator.start(targetWithIdentifier: uuid)
+        }
+        catch{
+        result(FlutterError(code: "DFU_FIRMWARE_NOT_FOUND", message: "Could not dfu zip file", details: nil))
+            return
+        }
     }
     
 //    MARK: DFUServiceDelegate


### PR DESCRIPTION
The DFULibrary dependency has been updated to V4.13.0, BUT, as mentionned in the iOSDFULibrary github changelog : https://github.com/NordicSemiconductor/IOS-DFU-Library/releases

" Breaking: Creating DFUFirmware may now throw an error by @philips77 in NordicSemiconductor/IOS-DFU-Library#486 Logging improvements by @philips77 in NordicSemiconductor/IOS-DFU-Library#487 "

So the code need to be change to a "do/try/catch", as the previous "gard/else" is now throwing errors at the build.