### PR TITLE
Parallel Update

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -26,5 +26,14 @@
 
     <application>
         <service android:name=".DfuService" />
+        <service android:name=".DfuService2" />
+        <service android:name=".DfuService3" />
+        <service android:name=".DfuService4" />
+        <service android:name=".DfuService5" />
+        <service android:name=".DfuService6" />
+        <service android:name=".DfuService7" />
+        <service android:name=".DfuService8" />
+        <service android:name=".DfuService9" />
+        <service android:name=".DfuService10" />
     </application>
 </manifest>

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService10.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService10.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService10 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService2.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService2.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService2 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService3.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService3.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService3 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService4.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService4.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService4 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService5.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService5.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService5 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService6.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService6.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService6 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService7.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService7.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService7 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService8.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService8.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService8 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService9.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService9.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService9 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfuPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfuPlugin.kt
@@ -12,6 +12,7 @@ import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import no.nordicsemi.android.dfu.DfuBaseService
 import no.nordicsemi.android.dfu.DfuBaseService.NOTIFICATION_ID
 import no.nordicsemi.android.dfu.DfuProgressListenerAdapter
 import no.nordicsemi.android.dfu.DfuServiceController
@@ -30,6 +31,21 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
 
     private var controller: DfuServiceController? = null
     private var hasCreateNotification = false
+
+    private var update_counter = 0
+
+    private var dfuServiceClasses = arrayListOf<Class<out DfuBaseService>>(
+        DfuService::class.java,
+        DfuService2::class.java,
+        DfuService3::class.java,
+        DfuService4::class.java,
+        DfuService5::class.java,
+        DfuService6::class.java,
+        DfuService7::class.java,    
+        DfuService8::class.java,
+        DfuService9::class.java,
+        DfuService10::class.java,
+    )
 
     override fun onAttachedToEngine(binding: FlutterPluginBinding) {
         mContext = binding.applicationContext
@@ -182,7 +198,13 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
                 hasCreateNotification = true
             }
         }
-        controller = starter.start(mContext!!, DfuService::class.java)
+
+        var unusedServiceClass = getUnusedServiceClass(address);
+        controller = starter.start(mContext!!, unusedServiceClass)
+    }
+
+    private fun getUnusedServiceClass(address : String): Class<out DfuBaseService> {
+        return dfuServiceClasses.elementAt(update_counter++ % dfuServiceClasses.size)
     }
 
     private fun cancelNotification() {


### PR DESCRIPTION
## Ways to reproduce:
Calling `NordicDfu.start()` for multiple devices without waiting them to finish

```dart
final futures = <Future>[];
for (var dfuDevice in _dfuDevices) {
  futures.add(NordicDfu().startDfu(dfuDevice.device.macAddress, "assets/dfu.zip",
      name: dfuDevice.device.name,
      onProgressChanged: onProgressChanged,
      onDfuCompleted: onDfuCompleted,
      onError: onError,
      onDfuAborted: onDfuAborted,
      onDeviceDisconnected: onDeviceDisconnected));
}
await Future.wait(futures);
```

## Expected behaviour
- Devices should be updated parallel
- Callbacks like `onProgressChanged` should be called for all devices

## Behaviour
### Android
- ❌ Devices were updated one after each other
- ❌ Callbacks like `onProgressChanged` were only called for the first device that was updated

### iOS
- ✅ Devices were updated parallel 
- ❌ Callbacks like `onProgressChanged` were only called for the first device that was updated


## Fixes
### Android code base
- Multiple `DfuService` instances can now be used (thanks to @davidgyoung `s [comment](https://github.com/NordicSemiconductor/Android-DFU-Library/issues/213#issuecomment-777844288))

### Flutter code base
- Broadcast stream subscription is not cancelled anymore when first device is finished