### PR TITLE
Add Parallel DFU Support

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jul 13 09:14:07 BRT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -27,5 +27,28 @@
         <service android:name=".DfuService"
             android:foregroundServiceType="connectedDevice"
             android:exported="false"/>
+        <service android:name=".DfuService2"
+            android:foregroundServiceType="connectedDevice"
+            android:exported="false"/>
+        <service android:name=".DfuService3"
+            android:foregroundServiceType="connectedDevice"
+            android:exported="false"/>
+        <service android:name=".DfuService4"
+            android:foregroundServiceType="connectedDevice"
+            android:exported="false"/>
+        <service android:name=".DfuService5"
+            android:foregroundServiceType="connectedDevice"
+            android:exported="false"/>
+        <service android:name=".DfuService6"
+            android:foregroundServiceType="connectedDevice"
+            android:exported="false"/>
+        <service android:name=".DfuService7"
+            android:foregroundServiceType="connectedDevice"
+            android:exported="false"/>
+        <service android:name=".DfuService8"
+            android:foregroundServiceType="connectedDevice"
+            android:exported="false"/>
+        <!-- more service classes can be added here to support more parallel DFU processes.
+             make sure to also update DFU_SERVICE_CLASSES in NordicDfuPlugin.kt -->
     </application>
 </manifest>

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService2.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService2.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService2 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService3.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService3.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService3 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService4.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService4.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService4 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService5.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService5.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService5 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService6.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService6.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService6 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService7.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService7.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService7 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService8.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuService8.kt
@@ -1,0 +1,17 @@
+package dev.steenbakker.nordicdfu
+
+import android.app.Activity
+import no.nordicsemi.android.dfu.DfuBaseService
+
+class DfuService8 : DfuBaseService() {
+    override fun getNotificationTarget(): Class<out Activity?> {
+        return NotificationActivity::class.java
+    }
+
+    override fun isDebug(): Boolean {
+        // Override this method and return true if you need more logs in LogCat
+        // Note: BuildConfig.DEBUG always returns false in library projects, so please use
+        // your app package BuildConfig
+        return true
+    }
+}

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfuPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfuPlugin.kt
@@ -161,6 +161,10 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
 
         if (address == null) {
             // Abort all DFU processes
+            if (activeDfuMap.isEmpty()) {
+                result.error("NO_ACTIVE_DFU", "No active DFU processes to abort", null)
+                return
+            }
             activeDfuMap.values.forEach { it.controller.abort() }
             result.success(null)
             return

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfuPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfuPlugin.kt
@@ -12,23 +12,44 @@ import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import no.nordicsemi.android.dfu.DfuBaseService
 import no.nordicsemi.android.dfu.DfuBaseService.NOTIFICATION_ID
 import no.nordicsemi.android.dfu.DfuProgressListenerAdapter
 import no.nordicsemi.android.dfu.DfuServiceController
 import no.nordicsemi.android.dfu.DfuServiceInitiator
 import no.nordicsemi.android.dfu.DfuServiceListenerHelper
 import java.util.*
+import android.util.Log
+
+private class DfuProcess(
+    val deviceAddress: String,
+    val controller: DfuServiceController,
+    val pendingResult: MethodChannel.Result,
+    val serviceClass: Class<out DfuBaseService>
+)
+
+private val DFU_SERVICE_CLASSES = arrayListOf<Class<out DfuBaseService>>(
+    DfuService::class.java,
+    DfuService2::class.java,
+    DfuService3::class.java,
+    DfuService4::class.java,
+    DfuService5::class.java,
+    DfuService6::class.java,
+    DfuService7::class.java,
+    DfuService8::class.java,
+    // more service classes can be added here to support more parallel DFU processes
+    // (make sure to also update AndroidManifest.xml)
+)
 
 class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHandler {
 
     private var mContext: Context? = null
 
-    private var pendingResult: MethodChannel.Result? = null
     private var methodChannel: MethodChannel? = null
     private var eventChannel: EventChannel? = null
     private var sink: EventChannel.EventSink? = null
+    private var activeDfuMap: MutableMap<String, DfuProcess> = mutableMapOf() 
 
-    private var controller: DfuServiceController? = null
     private var hasCreateNotification = false
 
     override fun onAttachedToEngine(binding: FlutterPluginBinding) {
@@ -50,7 +71,7 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {
             "startDfu" -> initiateDfu(call, result)
-            "abortDfu" -> abortDfu()
+            "abortDfu" -> abortDfu(call, result)
             else -> result.notImplemented()
         }
     }
@@ -107,7 +128,6 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
             // now, the path is an absolute path, and can pass it to nordic dfu libarary
             filePath = tempFileName
         }
-        pendingResult = result
         startDfu(
             address,
             name,
@@ -127,10 +147,39 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
         )
     }
 
-    private fun abortDfu() {
-        if (controller != null) {
-            controller!!.abort()
+    // Aborts ongoing DFU processes.
+    //
+    // If `call.argument("address")` is null, the abort command will be sent to all active DFU controllers
+    // If `call.argument("address")` is provided, the abort command will be sent to the specific DFU controller
+    // 
+    // Note: the underlying controller implementation does not currently support individual aborts;
+    // all active DFU processes are affected. See: https://github.com/NordicSemiconductor/Android-DFU-Library/blob/0c559244b34ebd27a4f51f045c067b965f918b73/lib/dfu/src/main/java/no/nordicsemi/android/dfu/DfuServiceController.java#L31-L39
+    // 
+    // Per-address abort handling is included here for cross-platform consistency and future compatability.
+    private fun abortDfu(call: MethodCall, result: MethodChannel.Result) {
+        val address = call.argument<String>("address")
+
+        if (address == null) {
+            // Abort all DFU processes
+            activeDfuMap.values.forEach { it.controller.abort() }
+            result.success(null)
+            return
         }
+
+        // Abort DFU process for the specified address
+        val process = activeDfuMap[address]
+        if (process == null) {
+            result.error("INVALID_ADDRESS", "No DFU process found for address: $address", null)
+            return
+        }
+
+        // Log a warning if multiple DFU processes are active
+        if (activeDfuMap.size > 1) {
+            Log.w("[NordicDfu]", "abortDfu will abort all DFU processes")
+        }
+
+        process.controller.abort()
+        result.success(null)
     }
 
     private fun startDfu(
@@ -180,7 +229,6 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
         if (rebootTime != null) {
             starter.setRebootTime(rebootTime)
         }
-        pendingResult = result
 
         // fix notification on android 8 and above
         if (startAsForegroundService == null || startAsForegroundService) {
@@ -189,7 +237,25 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
                 hasCreateNotification = true
             }
         }
-        controller = starter.start(mContext!!, DfuService::class.java)
+
+        val serviceClass = getAvailableDfuServiceClass() ?: run {
+            result.error("PARALLEL_LIMIT_REACHED", "No available DFU service slots", null)
+            return
+        }
+        val controller = starter.start(mContext!!, serviceClass)
+
+        activeDfuMap[address] = DfuProcess(
+            deviceAddress = address,
+            controller = controller,
+            pendingResult = result,
+            serviceClass = serviceClass
+        )
+    }
+
+    private fun getAvailableDfuServiceClass(): Class<out DfuBaseService>? {
+        return DFU_SERVICE_CLASSES.firstOrNull { serviceClass ->
+            activeDfuMap.values.none { it.serviceClass == serviceClass }
+        }
     }
 
     private fun cancelNotification() {
@@ -219,14 +285,12 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
                 parameters["errorType"] = errorType
                 parameters["message"] = message
                 sink?.success(mapOf("onError" to parameters))
-                if (pendingResult != null) {
-                    pendingResult!!.error(
-                        "$error",
-                        "DFU FAILED: $message",
-                        "Address: $deviceAddress, Error Type: $errorType"
-                    )
-                    pendingResult = null
-                }
+                activeDfuMap[deviceAddress]?.pendingResult?.error(
+                    "$error",
+                    "DFU FAILED: $message",
+                    "Address: $deviceAddress, Error Type: $errorType"
+                )
+                activeDfuMap.remove(deviceAddress)
             }
 
             override fun onDeviceConnecting(deviceAddress: String) {
@@ -248,18 +312,18 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
                 super.onDfuAborted(deviceAddress)
                 cancelNotification()
                 sink?.success(mapOf("onDfuAborted" to deviceAddress))
-                pendingResult?.error(
+                activeDfuMap[deviceAddress]?.pendingResult?.error(
                     "DFU_ABORTED", "DFU ABORTED by user", "device address: $deviceAddress"
                 )
-                pendingResult = null
+                activeDfuMap.remove(deviceAddress)
             }
 
             override fun onDfuCompleted(deviceAddress: String) {
                 super.onDfuCompleted(deviceAddress)
                 cancelNotification()
                 sink?.success(mapOf("onDfuCompleted" to deviceAddress))
-                pendingResult?.success(deviceAddress)
-                pendingResult = null
+                activeDfuMap[deviceAddress]?.pendingResult?.success(deviceAddress)
+                activeDfuMap.remove(deviceAddress)
             }
 
             override fun onDfuProcessStarted(deviceAddress: String) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -127,6 +127,11 @@ class _MyAppState extends State<MyApp> {
         appBar: AppBar(
           title: const Text('Plugin example app'),
           actions: <Widget>[
+            if (anyDfuRunning)
+              TextButton(
+                onPressed: NordicDfu().abortDfu,
+                child: const Text('Abort Dfu'),
+              ),
             if (isScanning)
               IconButton(
                 icon: const Icon(Icons.pause_circle_filled),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,6 +10,16 @@ import 'package:permission_handler/permission_handler.dart';
 
 void main() => runApp(const MyApp());
 
+class ExampleDfuState {
+  bool dfuRunning = false;
+  int? progressPercent;
+
+  ExampleDfuState({
+    required this.dfuRunning,
+    this.progressPercent,
+  });
+}
+
 class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
 
@@ -20,12 +30,14 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   StreamSubscription<ScanResult>? scanSubscription;
   List<ScanResult> scanResults = <ScanResult>[];
-  bool dfuRunning = false;
-  int? dfuRunningInx;
+  Map<String, ExampleDfuState> dfuStateMap = {};
+  bool get anyDfuRunning => dfuStateMap.values.any((state)=>state.dfuRunning);
 
   Future<void> doDfu(String deviceId) async {
     stopScan();
-    dfuRunning = true;
+    setState((){
+      dfuStateMap[deviceId] = ExampleDfuState(dfuRunning: true);
+    });
 
     final result = await FilePicker.platform.pickFiles();
 
@@ -49,13 +61,20 @@ class _MyAppState extends State<MyApp> {
           partsTotal,
         ) {
           debugPrint('deviceAddress: $deviceAddress, percent: $percent');
+          setState((){
+            dfuStateMap[deviceId]?.progressPercent = percent;
+          });
         },
         // androidSpecialParameter: const AndroidSpecialParameter(rebootTime: 1000),
       );
       debugPrint(s);
-      dfuRunning = false;
+      setState((){
+        dfuStateMap[deviceId]?.dfuRunning = false;
+      });
     } catch (e) {
-      dfuRunning = false;
+      setState((){
+        dfuStateMap[deviceId]?.dfuRunning = false;
+      });
       debugPrint(e.toString());
     }
   }
@@ -111,12 +130,12 @@ class _MyAppState extends State<MyApp> {
             if (isScanning)
               IconButton(
                 icon: const Icon(Icons.pause_circle_filled),
-                onPressed: dfuRunning ? null : stopScan,
+                onPressed: anyDfuRunning ? null : stopScan,
               )
             else
               IconButton(
                 icon: const Icon(Icons.play_arrow),
-                onPressed: dfuRunning ? null : startScan,
+                onPressed: anyDfuRunning ? null : startScan,
               ),
           ],
         ),
@@ -136,25 +155,13 @@ class _MyAppState extends State<MyApp> {
 
   Widget _deviceItemBuilder(BuildContext context, int index) {
     final result = scanResults[index];
+    final deviceId = result.device.remoteId.str;
     return DeviceItem(
-      isRunningItem: dfuRunningInx == index,
+      dfuState: dfuStateMap[deviceId],
       scanResult: result,
-      onPress: dfuRunning
-          ? () async {
-              await NordicDfu().abortDfu();
-              setState(() {
-                dfuRunningInx = null;
-              });
-            }
-          : () async {
-              setState(() {
-                dfuRunningInx = index;
-              });
-              await doDfu(result.device.remoteId.str);
-              setState(() {
-                dfuRunningInx = null;
-              });
-            },
+      onPress: dfuStateMap[deviceId]?.dfuRunning ?? false
+        ? () => NordicDfu().abortDfu(address: deviceId)
+        : () => doDfu(deviceId)
     );
   }
 }
@@ -186,14 +193,21 @@ class DeviceItem extends StatelessWidget {
 
   final VoidCallback? onPress;
 
-  final bool? isRunningItem;
+  final ExampleDfuState? dfuState;
 
   const DeviceItem({
     required this.scanResult,
     this.onPress,
-    this.isRunningItem,
+    this.dfuState,
     Key? key,
   }) : super(key: key);
+
+  String _getDfuButtonText() {
+    final progressText = dfuState?.progressPercent != null
+      ? '\n(${dfuState!.progressPercent}%)'
+      : '';
+    return (dfuState?.dfuRunning == true ? 'Abort Dfu' : 'Start Dfu') + progressText;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -219,9 +233,10 @@ class DeviceItem extends StatelessWidget {
             ),
             TextButton(
               onPressed: onPress,
-              child: isRunningItem!
-                  ? const Text('Abort Dfu')
-                  : const Text('Start Dfu'),
+              child: Text(
+                _getDfuButtonText(),
+                textAlign: TextAlign.center,
+              )
             ),
           ],
         ),

--- a/ios/Classes/SwiftNordicDfuPlugin.swift
+++ b/ios/Classes/SwiftNordicDfuPlugin.swift
@@ -54,6 +54,10 @@ public class SwiftNordicDfuPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
 
         if address == nil {
             // Abort all DFU processes
+            if activeDfuMap.isEmpty {
+                result(FlutterError(code: "NO_ACTIVE_DFU", message: "No active DFU processes to abort", details: nil))
+                return
+            }
             for (_, process) in activeDfuMap {
                 process.controller?.abort()
             }

--- a/ios/Classes/SwiftNordicDfuPlugin.swift
+++ b/ios/Classes/SwiftNordicDfuPlugin.swift
@@ -3,14 +3,12 @@ import UIKit
 import NordicDFU
 import CoreBluetooth
 
-public class SwiftNordicDfuPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, DFUServiceDelegate, DFUProgressDelegate, LoggerDelegate {
+public class SwiftNordicDfuPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, LoggerDelegate {
     
     let registrar: FlutterPluginRegistrar
-    var sink: FlutterEventSink!
-    var pendingResult: FlutterResult?
-    var deviceAddress: String?
-    private var dfuController : DFUServiceController!
-    
+    private var sink: FlutterEventSink?
+    private var activeDfuMap: [String: DfuProcess] = [:]
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let instance = SwiftNordicDfuPlugin(registrar)
         
@@ -31,7 +29,7 @@ public class SwiftNordicDfuPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "startDfu": initializeDfu(call, result)
-        case "abortDfu" : abortDfu()
+        case "abortDfu" : abortDfu(call, result)
         default: result(FlutterMethodNotImplemented)
         }
     }
@@ -46,9 +44,31 @@ public class SwiftNordicDfuPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
         return nil
     }
     
-    private func abortDfu() {
-        _ = dfuController?.abort()
-        dfuController = nil
+    // Aborts ongoing DFU process(es)
+    //
+    // If `call.arguments["address"]` is `nil`, the method aborts all active DFU processes
+    // If `call.arguments["address"]` contains a specific address, the method aborts the DFU process for that address
+    private func abortDfu(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        let arguments = call.arguments as? [String: Any]
+        let address = arguments?["address"] as? String
+
+        if address == nil {
+            // Abort all DFU processes
+            for (_, process) in activeDfuMap {
+                process.controller?.abort()
+            }
+            result(nil)
+            return
+        }
+
+        // Abort DFU process for the specified address
+        guard let process = activeDfuMap[address!] else {
+            result(FlutterError(code: "INVALID_ADDRESS", message: "No DFU process found for address: \(address!).", details: nil))
+            return
+        }
+
+        process.controller?.abort()
+        result(nil)
     }
  
     private func initializeDfu(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
@@ -56,22 +76,13 @@ public class SwiftNordicDfuPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
             result(FlutterError(code: "ABNORMAL_PARAMETER", message: "no parameters", details: nil))
             return
         }
-        let name = arguments["name"] as? String
         guard let address = arguments["address"] as? String,
-            var filePath = arguments["filePath"] as? String else {
-                result(FlutterError(code: "ABNORMAL_PARAMETER", message: "address and filePath are required", details: nil))
-                return
+              var filePath = arguments["filePath"] as? String else {
+            result(FlutterError(code: "ABNORMAL_PARAMETER", message: "address and filePath are required", details: nil))
+            return
         }
-        
-        let forceDfu = arguments["forceDfu"] as? Bool
-        let forceScanningForNewAddressInLegacyDfu = arguments["forceScanningForNewAddressInLegacyDfu"] as? Bool
-        let packetReceiptNotificationParameter = arguments["packetReceiptNotificationParameter"] as? UInt16
-        let connectionTimeout = arguments["connectionTimeout"] as? TimeInterval
-        let dataObjectPreparationDelay = arguments["dataObjectPreparationDelay"] as? TimeInterval
-        let alternativeAdvertisingNameEnabled = arguments["alternativeAdvertisingNameEnabled"] as? Bool
-        let alternativeAdvertisingName = arguments["alternativeAdvertisingName"] as? String
-        let enableUnsafeExperimentalButtonlessServiceInSecureDfu = arguments["enableUnsafeExperimentalButtonlessServiceInSecureDfu"] as? Bool
-        let disableResume = arguments["disableResume"] as? Bool
+
+        let options = DfuOptions(arguments: arguments)
 
         let fileInAsset = (arguments["fileInAsset"] as? Bool) ?? false
         
@@ -81,38 +92,20 @@ public class SwiftNordicDfuPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
                 result(FlutterError(code: "ABNORMAL_PARAMETER", message: "file in asset not found \(filePath)", details: nil))
                 return
             }
-            
+
             filePath = pathInAsset
         }
         
         startDfu(address,
-                 name: name,
                  filePath: filePath,
-                 packetReceiptNotificationParameter: packetReceiptNotificationParameter,
-                 forceDfu: forceDfu,
-                 forceScanningForNewAddressInLegacyDfu: forceScanningForNewAddressInLegacyDfu,
-                 connectionTimeout: connectionTimeout,
-                 dataObjectPreparationDelay: dataObjectPreparationDelay,
-                 alternativeAdvertisingNameEnabled: alternativeAdvertisingNameEnabled,
-                 alternativeAdvertisingName: alternativeAdvertisingName,
-                 enableUnsafeExperimentalButtonlessServiceInSecureDfu: enableUnsafeExperimentalButtonlessServiceInSecureDfu,
-                 disableResume: disableResume,
+                 options: options,
                  result: result)
     }
     
     private func startDfu(
         _ address: String,
-        name: String?,
         filePath: String,
-        packetReceiptNotificationParameter: UInt16?,
-        forceDfu: Bool?,
-        forceScanningForNewAddressInLegacyDfu: Bool?,
-        connectionTimeout: TimeInterval?,
-        dataObjectPreparationDelay: TimeInterval?,
-        alternativeAdvertisingNameEnabled: Bool?,
-        alternativeAdvertisingName: String?,
-        enableUnsafeExperimentalButtonlessServiceInSecureDfu: Bool?,
-        disableResume: Bool?,
+        options: DfuOptions,
         result: @escaping FlutterResult) {
         guard let uuid = UUID(uuidString: address) else {
             result(FlutterError(code: "DEVICE_ADDRESS_ERROR", message: "Device address conver to uuid failed", details: "Device uuid \(address) convert to uuid failed"))
@@ -122,48 +115,31 @@ public class SwiftNordicDfuPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
         do {
             let firmware = try DFUFirmware(urlToZipFile: URL(fileURLWithPath: filePath))
             
-            let dfuInitiator = DFUServiceInitiator(queue: nil)
-                .with(firmware: firmware);
-            dfuInitiator.delegate = self
-            dfuInitiator.progressDelegate = self
-            dfuInitiator.logger = self
-            
-            packetReceiptNotificationParameter.map { dfuInitiator.packetReceiptNotificationParameter = $0 }
-            forceDfu.map { dfuInitiator.forceDfu = $0 }
-            forceScanningForNewAddressInLegacyDfu.map { dfuInitiator.forceScanningForNewAddressInLegacyDfu = $0 }
-            connectionTimeout.map { dfuInitiator.connectionTimeout = $0 }
-            dataObjectPreparationDelay.map { dfuInitiator.dataObjectPreparationDelay = $0 }
-            alternativeAdvertisingNameEnabled.map { dfuInitiator.alternativeAdvertisingNameEnabled = $0 }
-            alternativeAdvertisingName.map { dfuInitiator.alternativeAdvertisingName = $0 }
-            enableUnsafeExperimentalButtonlessServiceInSecureDfu.map { dfuInitiator.enableUnsafeExperimentalButtonlessServiceInSecureDfu = $0 }
-//            uuidHelper.map { dfuInitiator.uuidHelper = $0 }
-            disableResume.map { dfuInitiator.disableResume = $0 }
-            
-            pendingResult = result
-            deviceAddress = address
-            
-            dfuController = dfuInitiator.start(targetWithIdentifier: uuid)
-        }
-        catch{
-        result(FlutterError(code: "DFU_FIRMWARE_NOT_FOUND", message: "Could not dfu zip file", details: nil))
+            activeDfuMap[address] = DfuProcess(
+                deviceAddress: address,
+                firmware: firmware,
+                uuid: uuid,
+                delegate: self,
+                result: result,
+                options: options)
+        } catch {
+            result(FlutterError(code: "DFU_FIRMWARE_NOT_FOUND", message: "Could not dfu zip file", details: nil))
             return
         }
     }
-    
-//    MARK: DFUServiceDelegate
-    public func dfuStateDidChange(to state: DFUState) {
+
+    func dfuStateDidChange(to state: DFUState, deviceAddress: String) {
         switch state {
         case .completed:
             sink?(["onDfuCompleted":deviceAddress])
-            pendingResult?(deviceAddress)
-            pendingResult = nil
-            dfuController = nil
+            activeDfuMap[deviceAddress]?.pendingResult(deviceAddress)
+            activeDfuMap.removeValue(forKey: deviceAddress)
         case .disconnecting:
             sink?(["onDeviceDisconnecting":deviceAddress])
         case .aborted:
-            sink?(["onDfuAborted": deviceAddress])
-            pendingResult?(FlutterError(code: "DFU_ABORTED", message: "DFU ABORTED by user", details: "device address: \(deviceAddress!)"))
-            pendingResult = nil
+            sink?(["onDfuAborted":deviceAddress])
+            activeDfuMap[deviceAddress]?.pendingResult(FlutterError(code: "DFU_ABORTED", message: "DFU aborted by user", details: "device address: \(deviceAddress)"))
+            activeDfuMap.removeValue(forKey: deviceAddress)
         case .connecting:
             sink?(["onDeviceConnecting":deviceAddress])
         case .starting:
@@ -176,20 +152,129 @@ public class SwiftNordicDfuPlugin: NSObject, FlutterPlugin, FlutterStreamHandler
             sink?(["onFirmwareUploading":deviceAddress])
         }
     }
-    
-    public func dfuError(_ error: DFUError, didOccurWithMessage message: String) {
-        sink?(["onError":["deviceAddress": deviceAddress!, "error": error.rawValue, "errorType":error.rawValue, "message": message]])
-        pendingResult?(FlutterError(code: "\(error.rawValue)", message: "DFU FAILED: \(message)", details: "Address: \(deviceAddress!), Error type \(error.rawValue)"))
-        pendingResult = nil
+
+    func dfuError(_ error: DFUError, didOccurWithMessage message: String, deviceAddress: String) {
+        sink?(["onError": [
+            "deviceAddress": deviceAddress,
+            "error": error.rawValue,
+            "errorType": error.rawValue,
+            "message": message
+        ]])
+        
+        activeDfuMap[deviceAddress]?.pendingResult(FlutterError(code: "\(error.rawValue)", message: "DFU FAILED: \(message)", details: "Address: \(deviceAddress), Error type \(error.rawValue)"))
+        activeDfuMap.removeValue(forKey: deviceAddress)
     }
-    
-    //MARK: DFUProgressDelegate
-    public func dfuProgressDidChange(for part: Int, outOf totalParts: Int, to progress: Int, currentSpeedBytesPerSecond: Double, avgSpeedBytesPerSecond: Double) {
-        sink?(["onProgressChanged":["deviceAddress": deviceAddress!, "percent": progress, "speed":currentSpeedBytesPerSecond, "avgSpeed": avgSpeedBytesPerSecond, "currentPart": part, "partsTotal": totalParts]])
+
+    func dfuProgressDidChange(for part: Int, outOf totalParts: Int, to progress: Int, currentSpeedBytesPerSecond: Double, avgSpeedBytesPerSecond: Double, deviceAddress: String) {
+        sink?(["onProgressChanged":["deviceAddress": deviceAddress, "percent": progress, "speed":currentSpeedBytesPerSecond, "avgSpeed": avgSpeedBytesPerSecond, "currentPart": part, "partsTotal": totalParts]])
     }
-    
+
     //MARK: - LoggerDelegate
     public func logWith(_ level: LogLevel, message: String) {
         print("\(level.name()): \(message)")
+    }
+}
+
+private struct DfuOptions {
+    let name: String?
+    let packetReceiptNotificationParameter: UInt16?
+    let forceDfu: Bool?
+    let forceScanningForNewAddressInLegacyDfu: Bool?
+    let connectionTimeout: TimeInterval?
+    let dataObjectPreparationDelay: TimeInterval?
+    let alternativeAdvertisingNameEnabled: Bool?
+    let alternativeAdvertisingName: String?
+    let enableUnsafeExperimentalButtonlessServiceInSecureDfu: Bool?
+    let disableResume: Bool?
+
+    init(arguments: [String: Any]) {
+        self.name = arguments["name"] as? String
+        self.packetReceiptNotificationParameter = arguments["packetReceiptNotificationParameter"] as? UInt16
+        self.forceDfu = arguments["forceDfu"] as? Bool
+        self.forceScanningForNewAddressInLegacyDfu = arguments["forceScanningForNewAddressInLegacyDfu"] as? Bool
+        self.connectionTimeout = arguments["connectionTimeout"] as? TimeInterval
+        self.dataObjectPreparationDelay = arguments["dataObjectPreparationDelay"] as? TimeInterval
+        self.alternativeAdvertisingNameEnabled = arguments["alternativeAdvertisingNameEnabled"] as? Bool
+        self.alternativeAdvertisingName = arguments["alternativeAdvertisingName"] as? String
+        self.enableUnsafeExperimentalButtonlessServiceInSecureDfu = arguments["enableUnsafeExperimentalButtonlessServiceInSecureDfu"] as? Bool
+        self.disableResume = arguments["disableResume"] as? Bool
+    }
+}
+
+private func configureDfuInitiator(
+    _ dfuInitiator: DFUServiceInitiator,
+    with options: DfuOptions
+) {
+    options.packetReceiptNotificationParameter.map { dfuInitiator.packetReceiptNotificationParameter = $0 }
+    options.forceDfu.map { dfuInitiator.forceDfu = $0 }
+    options.forceScanningForNewAddressInLegacyDfu.map { dfuInitiator.forceScanningForNewAddressInLegacyDfu = $0 }
+    options.connectionTimeout.map { dfuInitiator.connectionTimeout = $0 }
+    options.dataObjectPreparationDelay.map { dfuInitiator.dataObjectPreparationDelay = $0 }
+    options.alternativeAdvertisingNameEnabled.map { dfuInitiator.alternativeAdvertisingNameEnabled = $0 }
+    options.alternativeAdvertisingName.map { dfuInitiator.alternativeAdvertisingName = $0 }
+    options.enableUnsafeExperimentalButtonlessServiceInSecureDfu.map { dfuInitiator.enableUnsafeExperimentalButtonlessServiceInSecureDfu = $0 }
+    options.disableResume.map { dfuInitiator.disableResume = $0 }
+}
+
+private class DfuProcess {
+    let controller: DFUServiceController?
+    let pendingResult: FlutterResult
+    let deviceDelegate: DeviceScopedDFUDelegate
+
+    init(
+        deviceAddress: String,
+        firmware: DFUFirmware,
+        uuid: UUID,
+        delegate: SwiftNordicDfuPlugin,
+        result: @escaping FlutterResult,
+        options: DfuOptions
+    ) {
+        self.pendingResult = result
+        self.deviceDelegate = DeviceScopedDFUDelegate(
+            delegate: delegate,
+            deviceAddress: deviceAddress
+        )
+
+        let dfuInitiator = DFUServiceInitiator(queue: nil)
+            .with(firmware: firmware)
+
+        dfuInitiator.delegate = self.deviceDelegate
+        dfuInitiator.progressDelegate = self.deviceDelegate
+        dfuInitiator.logger = delegate
+
+        configureDfuInitiator(dfuInitiator, with: options)
+        
+        self.controller = dfuInitiator.start(targetWithIdentifier: uuid)
+    }
+}
+
+// Handles DFU service and progress updates for a specific device
+public class DeviceScopedDFUDelegate: NSObject, DFUServiceDelegate, DFUProgressDelegate {
+    private let originalDelegate: SwiftNordicDfuPlugin
+    private let deviceAddress: String
+
+    init(delegate: SwiftNordicDfuPlugin, deviceAddress: String) {
+        self.originalDelegate = delegate
+        self.deviceAddress = deviceAddress
+    }
+
+    //MARK: DFUServiceDelegate
+    public func dfuStateDidChange(to state: DFUState) {
+        originalDelegate.dfuStateDidChange(to: state, deviceAddress: deviceAddress)
+    }
+    public func dfuError(_ error: DFUError, didOccurWithMessage message: String) {
+        originalDelegate.dfuError(error, didOccurWithMessage: message, deviceAddress: deviceAddress)
+    }
+
+    //MARK: DFUProgressDelegate
+    public func dfuProgressDidChange(for part: Int, outOf totalParts: Int, to progress: Int, currentSpeedBytesPerSecond: Double, avgSpeedBytesPerSecond: Double) {
+        originalDelegate.dfuProgressDidChange(
+            for: part,
+            outOf: totalParts,
+            to: progress,
+            currentSpeedBytesPerSecond: currentSpeedBytesPerSecond,
+            avgSpeedBytesPerSecond: avgSpeedBytesPerSecond,
+            deviceAddress: deviceAddress
+        )
     }
 }


### PR DESCRIPTION
# Add Parallel DFU Support

Adds the ability to handle multiple concurrent DFU processes. 

### Concurrent DFU Processes
- DFU operations can run simultaneously on multiple devices.
- Callbacks are triggered correctly and independently for each device.

### Interface change
- Updated `abortDfu` method to include an optional `address` parameter:
  - **If an address is provided:** The DFU process for the specified device will be aborted. **(iOS only)**
  - **If no address is provided:** All active DFU processes will be aborted.
- Added error handling for `abortDfu`:
  - `FlutterError("INVALID_ADDRESS")` is thrown if the provided address does not match any active DFU process.
  - `FlutterError("NO_ACTIVE_DFU")` is thrown if no address is provided and there are no active DFU processes.

### Updated example project
- Added support for starting and aborting DFU processes in parallel
  - 'Abort Dfu' button in DeviceItem list calls `NordicDfu().abortDfu(address: deviceId)`
- Added 'Abort Dfu' button to app bar to call `NordicDfu().abortDfu()`
- Updated DeviceItem UI: display DFU progress percent 

---

### iOS
- ✅ Devices update in parallel.
- ✅ Callbacks set in `startDfu` are called independently for each device.
- ✅ All active DFU processes can be aborted using the `abortDfu` method without an `address`.
- ✅ DFU processes can be individually aborted using the `abortDfu` method with an `address`.

### Android
- ✅ Devices update in parallel (set limit of 8).
- ✅ Callbacks set in `startDfu`  are called independently for each device.
- ✅ All active DFU processes can be aborted using the `abortDfu` method without an `address`.
- ❌ DFU processes cannot be individually aborted using the `abortDfu` method with an `address` due to current limitations in the underlying [Android-DFU-Library](https://github.com/NordicSemiconductor/Android-DFU-Library).

---

Android functionality is based on https://github.com/juliansteenbakker/nordic_dfu/pull/96
