### PR TITLE
feat: DFU Address Mapping Feature Implementation

### DIFF
--- a/ADDRESS_MAPPING.md
+++ b/ADDRESS_MAPPING.md
@@ -1,0 +1,54 @@
+# Nordic DFU Address Mapping Feature
+
+## Overview
+
+This document explains the Address Mapping feature.
+
+## What is Address Mapping?
+
+During firmware updates for Bluetooth devices, the device's MAC address can change when it enters DFU mode. The Address Mapping feature provides a way to track and translate between a device's original address and its DFU mode address, ensuring that events and callbacks are correctly associated with the right device throughout the update process.
+
+## Why Address Mapping is Important
+
+When a Bluetooth device enters DFU mode, it often advertises itself with a different MAC address. For example, most devices implement the "plus 1" operation, where the DFU mode address is derived by incrementing the original MAC address by 1.
+
+For example:
+- Original device address: `C8:DF:84:12:34:56`
+- DFU mode address: `C8:DF:84:12:34:57` (last byte incremented by 1)
+
+Without address mapping, the application would lose track of the device during the critical firmware update process, as it would appear as a completely different device.
+
+## Added Functionality
+
+
+```dart
+// Before starting DFU
+void startFirmwareUpdate() {
+// Get the original device address
+String originalAddress = device.remoteId.str;
+
+// When the device enters DFU mode and you detect the new address
+String dfuModeAddress = dfuDevice.remoteId.str;
+
+// Set the mapping in the Nordic DFU instance
+NordicDfu().setAddressMapping(dfuModeAddress, originalAddress);
+
+// Start the DFU process
+NordicDfu().startDfu(originalAddress, firmwareFilePath, ...);
+}
+```
+
+To make it dynamic, you can use like this:
+```dart
+// When enabling DFU mode for the device
+onEnablingDfuMode: (deviceAddress) {
+  widget._logger.info(
+      "@onEnablingDfuMode[3]: ENABLING DFU MODE for $deviceAddress");
+  if (deviceAddress == deviceId) {
+    _startScanForDfuDevice();
+  }
+},
+
+// In the scan function, when the DFU device is found (for example by name)
+NordicDfu().setAddressMapping(dfuDevice.remoteId.str, deviceId);
+```

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Available from version 7.0.0
 - ✅ All active DFU processes can be aborted using the `abortDfu` method without an `address`.
 - ❌ DFU processes cannot be individually aborted using the `abortDfu` method with an `address` due to current limitations in the underlying [Android-DFU-Library](https://github.com/NordicSemiconductor/Android-DFU-Library).
 
+## Address Mapping
+The Nordic DFU library now includes an address mapping feature to track devices during firmware updates. [Read the full documentation](./ADDRESS_MAPPING.md) to learn how this improves reliability when devices change MAC addresses in DFU mode.
+
 ## Resources
 
 -   [DFU Introduction](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v11.0.0/examples_ble_dfu.html?cp=6_0_0_4_3_1 "BLE Bootloader/DFU")

--- a/lib/src/nordic_dfu.dart
+++ b/lib/src/nordic_dfu.dart
@@ -24,8 +24,36 @@ class NordicDfu {
   static const MethodChannel _methodChannel = MethodChannel(_methodChannelName);
   static const EventChannel _eventChannel = EventChannel(_eventChannelName);
 
+  // Private map to store address mappings (String -> String)
+  final Map<String, String> _addressMap = {};
+
   StreamSubscription<void>? _events;
   final Map<String, DfuEventHandler> _eventHandlerMap = {};
+
+  // Method to set new entries in the map
+  void setAddressMapping(String originalAddress, String translatedAddress) {
+    if (originalAddress.isNotEmpty && translatedAddress.isNotEmpty) {
+      _addressMap[originalAddress] = translatedAddress;
+    }
+  }
+
+  /// Method to get translated address or return original if not found
+  /// Return the translated address if it exists, otherwise return the original address
+  /// @param address the address to translate
+  String getTranslatedAddress(String address) {
+    return _addressMap[address] ?? address;
+  }
+
+  /// Method to remove a mapping
+  /// @param originalAddress the address to remove
+  void removeAddressMapping(String originalAddress) {
+    _addressMap.remove(originalAddress);
+  }
+
+  /// Method to clear all mappings
+  void clearAddressMappings() {
+    _addressMap.clear();
+  }
 
   void _ensureEventStreamSetup() {
     if (_events != null) return;
@@ -69,51 +97,52 @@ class NordicDfu {
       values = null;
     }
 
-    final handler = _eventHandlerMap[address];
-    handler?.dispatchEvent(key, values, address);
+    final translatedAddress = getTranslatedAddress(address);
+
+    final handler = _eventHandlerMap[translatedAddress];
+    handler?.dispatchEvent(key, values, translatedAddress);
   }
 
   /// Starts the DFU process.
-  Future<String?> startDfu(
-    String address,
-    String filePath, {
-    String? name,
-    bool fileInAsset = false,
-    bool forceDfu = false,
-    int? numberOfPackets,
-    bool enableUnsafeExperimentalButtonlessServiceInSecureDfu = false,
-    @Deprecated('Use androidParameters instead')
-    AndroidSpecialParameter? androidSpecialParameter,
-    @Deprecated('Use darwinParameters instead')
-    IosSpecialParameter? iosSpecialParameter,
-    AndroidParameters androidParameters = const AndroidParameters(),
-    DarwinParameters darwinParameters = const DarwinParameters(),
-    DfuEventHandler? dfuEventHandler,
-    @Deprecated('Use dfuEventHandler.onDeviceConnected instead')
-    DfuCallback? onDeviceConnected,
-    @Deprecated('Use dfuEventHandler.onDeviceConnecting instead')
-    DfuCallback? onDeviceConnecting,
-    @Deprecated('Use dfuEventHandler.onDeviceDisconnected instead')
-    DfuCallback? onDeviceDisconnected,
-    @Deprecated('Use dfuEventHandler.onDeviceDisconnecting instead')
-    DfuCallback? onDeviceDisconnecting,
-    @Deprecated('Use dfuEventHandler.onDfuAborted instead')
-    DfuCallback? onDfuAborted,
-    @Deprecated('Use dfuEventHandler.onDfuCompleted instead')
-    DfuCallback? onDfuCompleted,
-    @Deprecated('Use dfuEventHandler.onDfuProcessStarted instead')
-    DfuCallback? onDfuProcessStarted,
-    @Deprecated('Use dfuEventHandler.onDfuProcessStarting instead')
-    DfuCallback? onDfuProcessStarting,
-    @Deprecated('Use dfuEventHandler.onEnablingDfuMode instead')
-    DfuCallback? onEnablingDfuMode,
-    @Deprecated('Use dfuEventHandler.onFirmwareValidating instead')
-    DfuCallback? onFirmwareValidating,
-    @Deprecated('Use dfuEventHandler.onError instead')
-    DfuErrorCallback? onError,
-    @Deprecated('Use dfuEventHandler.onProgressChanged instead')
-    DfuProgressCallback? onProgressChanged,
-  }) async {
+  Future<String?> startDfu(String address,
+      String filePath, {
+        String? name,
+        bool fileInAsset = false,
+        bool forceDfu = false,
+        int? numberOfPackets,
+        bool enableUnsafeExperimentalButtonlessServiceInSecureDfu = false,
+        @Deprecated('Use androidParameters instead')
+        AndroidSpecialParameter? androidSpecialParameter,
+        @Deprecated('Use darwinParameters instead')
+        IosSpecialParameter? iosSpecialParameter,
+        AndroidParameters androidParameters = const AndroidParameters(),
+        DarwinParameters darwinParameters = const DarwinParameters(),
+        DfuEventHandler? dfuEventHandler,
+        @Deprecated('Use dfuEventHandler.onDeviceConnected instead')
+        DfuCallback? onDeviceConnected,
+        @Deprecated('Use dfuEventHandler.onDeviceConnecting instead')
+        DfuCallback? onDeviceConnecting,
+        @Deprecated('Use dfuEventHandler.onDeviceDisconnected instead')
+        DfuCallback? onDeviceDisconnected,
+        @Deprecated('Use dfuEventHandler.onDeviceDisconnecting instead')
+        DfuCallback? onDeviceDisconnecting,
+        @Deprecated('Use dfuEventHandler.onDfuAborted instead')
+        DfuCallback? onDfuAborted,
+        @Deprecated('Use dfuEventHandler.onDfuCompleted instead')
+        DfuCallback? onDfuCompleted,
+        @Deprecated('Use dfuEventHandler.onDfuProcessStarted instead')
+        DfuCallback? onDfuProcessStarted,
+        @Deprecated('Use dfuEventHandler.onDfuProcessStarting instead')
+        DfuCallback? onDfuProcessStarting,
+        @Deprecated('Use dfuEventHandler.onEnablingDfuMode instead')
+        DfuCallback? onEnablingDfuMode,
+        @Deprecated('Use dfuEventHandler.onFirmwareValidating instead')
+        DfuCallback? onFirmwareValidating,
+        @Deprecated('Use dfuEventHandler.onError instead')
+        DfuErrorCallback? onError,
+        @Deprecated('Use dfuEventHandler.onProgressChanged instead')
+        DfuProgressCallback? onProgressChanged,
+      }) async {
     _eventHandlerMap[address] = DfuEventHandler(
       onDeviceConnected:
           dfuEventHandler?.onDeviceConnected ?? onDeviceConnected,

--- a/lib/src/nordic_dfu.dart
+++ b/lib/src/nordic_dfu.dart
@@ -104,45 +104,46 @@ class NordicDfu {
   }
 
   /// Starts the DFU process.
-  Future<String?> startDfu(String address,
-      String filePath, {
-        String? name,
-        bool fileInAsset = false,
-        bool forceDfu = false,
-        int? numberOfPackets,
-        bool enableUnsafeExperimentalButtonlessServiceInSecureDfu = false,
-        @Deprecated('Use androidParameters instead')
-        AndroidSpecialParameter? androidSpecialParameter,
-        @Deprecated('Use darwinParameters instead')
-        IosSpecialParameter? iosSpecialParameter,
-        AndroidParameters androidParameters = const AndroidParameters(),
-        DarwinParameters darwinParameters = const DarwinParameters(),
-        DfuEventHandler? dfuEventHandler,
-        @Deprecated('Use dfuEventHandler.onDeviceConnected instead')
-        DfuCallback? onDeviceConnected,
-        @Deprecated('Use dfuEventHandler.onDeviceConnecting instead')
-        DfuCallback? onDeviceConnecting,
-        @Deprecated('Use dfuEventHandler.onDeviceDisconnected instead')
-        DfuCallback? onDeviceDisconnected,
-        @Deprecated('Use dfuEventHandler.onDeviceDisconnecting instead')
-        DfuCallback? onDeviceDisconnecting,
-        @Deprecated('Use dfuEventHandler.onDfuAborted instead')
-        DfuCallback? onDfuAborted,
-        @Deprecated('Use dfuEventHandler.onDfuCompleted instead')
-        DfuCallback? onDfuCompleted,
-        @Deprecated('Use dfuEventHandler.onDfuProcessStarted instead')
-        DfuCallback? onDfuProcessStarted,
-        @Deprecated('Use dfuEventHandler.onDfuProcessStarting instead')
-        DfuCallback? onDfuProcessStarting,
-        @Deprecated('Use dfuEventHandler.onEnablingDfuMode instead')
-        DfuCallback? onEnablingDfuMode,
-        @Deprecated('Use dfuEventHandler.onFirmwareValidating instead')
-        DfuCallback? onFirmwareValidating,
-        @Deprecated('Use dfuEventHandler.onError instead')
-        DfuErrorCallback? onError,
-        @Deprecated('Use dfuEventHandler.onProgressChanged instead')
-        DfuProgressCallback? onProgressChanged,
-      }) async {
+  Future<String?> startDfu(
+    String address,
+    String filePath, {
+      String? name,
+      bool fileInAsset = false,
+      bool forceDfu = false,
+      int? numberOfPackets,
+      bool enableUnsafeExperimentalButtonlessServiceInSecureDfu = false,
+      @Deprecated('Use androidParameters instead')
+      AndroidSpecialParameter? androidSpecialParameter,
+      @Deprecated('Use darwinParameters instead')
+      IosSpecialParameter? iosSpecialParameter,
+      AndroidParameters androidParameters = const AndroidParameters(),
+      DarwinParameters darwinParameters = const DarwinParameters(),
+      DfuEventHandler? dfuEventHandler,
+      @Deprecated('Use dfuEventHandler.onDeviceConnected instead')
+      DfuCallback? onDeviceConnected,
+      @Deprecated('Use dfuEventHandler.onDeviceConnecting instead')
+      DfuCallback? onDeviceConnecting,
+      @Deprecated('Use dfuEventHandler.onDeviceDisconnected instead')
+      DfuCallback? onDeviceDisconnected,
+      @Deprecated('Use dfuEventHandler.onDeviceDisconnecting instead')
+      DfuCallback? onDeviceDisconnecting,
+      @Deprecated('Use dfuEventHandler.onDfuAborted instead')
+      DfuCallback? onDfuAborted,
+      @Deprecated('Use dfuEventHandler.onDfuCompleted instead')
+      DfuCallback? onDfuCompleted,
+      @Deprecated('Use dfuEventHandler.onDfuProcessStarted instead')
+      DfuCallback? onDfuProcessStarted,
+      @Deprecated('Use dfuEventHandler.onDfuProcessStarting instead')
+      DfuCallback? onDfuProcessStarting,
+      @Deprecated('Use dfuEventHandler.onEnablingDfuMode instead')
+      DfuCallback? onEnablingDfuMode,
+      @Deprecated('Use dfuEventHandler.onFirmwareValidating instead')
+      DfuCallback? onFirmwareValidating,
+      @Deprecated('Use dfuEventHandler.onError instead')
+      DfuErrorCallback? onError,
+      @Deprecated('Use dfuEventHandler.onProgressChanged instead')
+      DfuProgressCallback? onProgressChanged,
+    }) async {
     _eventHandlerMap[address] = DfuEventHandler(
       onDeviceConnected:
           dfuEventHandler?.onDeviceConnected ?? onDeviceConnected,

--- a/lib/src/nordic_dfu.dart
+++ b/lib/src/nordic_dfu.dart
@@ -107,43 +107,43 @@ class NordicDfu {
   Future<String?> startDfu(
     String address,
     String filePath, {
-      String? name,
-      bool fileInAsset = false,
-      bool forceDfu = false,
-      int? numberOfPackets,
-      bool enableUnsafeExperimentalButtonlessServiceInSecureDfu = false,
-      @Deprecated('Use androidParameters instead')
-      AndroidSpecialParameter? androidSpecialParameter,
-      @Deprecated('Use darwinParameters instead')
-      IosSpecialParameter? iosSpecialParameter,
-      AndroidParameters androidParameters = const AndroidParameters(),
-      DarwinParameters darwinParameters = const DarwinParameters(),
-      DfuEventHandler? dfuEventHandler,
-      @Deprecated('Use dfuEventHandler.onDeviceConnected instead')
-      DfuCallback? onDeviceConnected,
-      @Deprecated('Use dfuEventHandler.onDeviceConnecting instead')
-      DfuCallback? onDeviceConnecting,
-      @Deprecated('Use dfuEventHandler.onDeviceDisconnected instead')
-      DfuCallback? onDeviceDisconnected,
-      @Deprecated('Use dfuEventHandler.onDeviceDisconnecting instead')
-      DfuCallback? onDeviceDisconnecting,
-      @Deprecated('Use dfuEventHandler.onDfuAborted instead')
-      DfuCallback? onDfuAborted,
-      @Deprecated('Use dfuEventHandler.onDfuCompleted instead')
-      DfuCallback? onDfuCompleted,
-      @Deprecated('Use dfuEventHandler.onDfuProcessStarted instead')
-      DfuCallback? onDfuProcessStarted,
-      @Deprecated('Use dfuEventHandler.onDfuProcessStarting instead')
-      DfuCallback? onDfuProcessStarting,
-      @Deprecated('Use dfuEventHandler.onEnablingDfuMode instead')
-      DfuCallback? onEnablingDfuMode,
-      @Deprecated('Use dfuEventHandler.onFirmwareValidating instead')
-      DfuCallback? onFirmwareValidating,
-      @Deprecated('Use dfuEventHandler.onError instead')
-      DfuErrorCallback? onError,
-      @Deprecated('Use dfuEventHandler.onProgressChanged instead')
-      DfuProgressCallback? onProgressChanged,
-    }) async {
+    String? name,
+    bool fileInAsset = false,
+    bool forceDfu = false,
+    int? numberOfPackets,
+    bool enableUnsafeExperimentalButtonlessServiceInSecureDfu = false,
+    @Deprecated('Use androidParameters instead')
+    AndroidSpecialParameter? androidSpecialParameter,
+    @Deprecated('Use darwinParameters instead')
+    IosSpecialParameter? iosSpecialParameter,
+    AndroidParameters androidParameters = const AndroidParameters(),
+    DarwinParameters darwinParameters = const DarwinParameters(),
+    DfuEventHandler? dfuEventHandler,
+    @Deprecated('Use dfuEventHandler.onDeviceConnected instead')
+    DfuCallback? onDeviceConnected,
+    @Deprecated('Use dfuEventHandler.onDeviceConnecting instead')
+    DfuCallback? onDeviceConnecting,
+    @Deprecated('Use dfuEventHandler.onDeviceDisconnected instead')
+    DfuCallback? onDeviceDisconnected,
+    @Deprecated('Use dfuEventHandler.onDeviceDisconnecting instead')
+    DfuCallback? onDeviceDisconnecting,
+    @Deprecated('Use dfuEventHandler.onDfuAborted instead')
+    DfuCallback? onDfuAborted,
+    @Deprecated('Use dfuEventHandler.onDfuCompleted instead')
+    DfuCallback? onDfuCompleted,
+    @Deprecated('Use dfuEventHandler.onDfuProcessStarted instead')
+    DfuCallback? onDfuProcessStarted,
+    @Deprecated('Use dfuEventHandler.onDfuProcessStarting instead')
+    DfuCallback? onDfuProcessStarting,
+    @Deprecated('Use dfuEventHandler.onEnablingDfuMode instead')
+    DfuCallback? onEnablingDfuMode,
+    @Deprecated('Use dfuEventHandler.onFirmwareValidating instead')
+    DfuCallback? onFirmwareValidating,
+    @Deprecated('Use dfuEventHandler.onError instead')
+    DfuErrorCallback? onError,
+    @Deprecated('Use dfuEventHandler.onProgressChanged instead')
+    DfuProgressCallback? onProgressChanged,
+  }) async {
     _eventHandlerMap[address] = DfuEventHandler(
       onDeviceConnected:
           dfuEventHandler?.onDeviceConnected ?? onDeviceConnected,


### PR DESCRIPTION
# Nordic DFU Address Mapping Feature Implementation

## Overview
This pull request adds an Address Mapping feature to the Nordic DFU library to solve the problem of tracking devices during firmware updates when MAC addresses change in DFU mode.

## Problem Addressed
When Bluetooth devices enter DFU mode, they often advertise with a different MAC address (commonly implementing a "plus 1" operation on the original address). This causes the application to lose track of the device during updates, as it appears as a completely different device.

## Solution Implemented
- Added a mapping system to translate between original device addresses and DFU mode addresses
- Implemented methods to set, get, remove, and clear address mappings
- Enhanced event handling to correctly route events using the translated addresses
- Documented the feature with examples and implementation details

## New Methods
- `setAddressMapping(String originalAddress, String translatedAddress)`
- `getTranslatedAddress(String address)`
- `removeAddressMapping(String originalAddress)`
- `clearAddressMappings()`

## Benefits
1. Maintains continuity in device identification throughout the DFU process
2. Simplifies event handling by correctly routing events from DFU mode devices
3. Enhances user experience with more accurate progress reporting

## Documentation
Full documentation is available in [ADDRESS_MAPPING.md](./ADDRESS_MAPPING.md)

## Testing
The feature has been tested with some Nordic devices that change addresses during DFU mode, particularly those implementing the "plus 1" pattern.