### PR TITLE
fix(android): add missing .zip extension to temp asset file path

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfuPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfuPlugin.kt
@@ -114,7 +114,7 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
             val loader = FlutterInjector.instance().flutterLoader()
             filePath = loader.getLookupKeyForAsset(filePath)
             val tempFileName =
-                (PathUtils.getExternalAppCachePath(mContext!!) + UUID.randomUUID().toString())
+                PathUtils.getExternalAppCachePath(mContext!!) + UUID.randomUUID().toString() + ".zip"
             // copy asset file to temp path
             if (!ResourceUtils.copyFileFromAssets(filePath, tempFileName, mContext!!)) {
                 result.error("File Error", "File not found!", "$filePath")


### PR DESCRIPTION
Ensures that asset files copied from the Flutter bundle have the correct .zip extension, preventing errors during the DFU process where not all parts are detected.

Resolves https://github.com/juliansteenbakker/nordic_dfu/issues/206