### PR TITLE
fix(spm): correct package identity for IOS-DFU-Library dependency

### DIFF
--- a/darwin/nordic_dfu/Package.swift
+++ b/darwin/nordic_dfu/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .target(
             name: "nordic_dfu",
             dependencies: [
-                .product(name: "NordicDFU", package: "NordicDFU")],
+                .product(name: "NordicDFU", package: "IOS-DFU-Library")],
             resources: [
                 .process("Resources"),
             ]


### PR DESCRIPTION
## Problem

On 7.1.x, resolving Swift Package Manager dependencies fails on iOS/macOS:

```
xcodebuild: error: Could not resolve package dependencies:
  unknown package 'NordicDFU' in dependencies of target 'nordic_dfu';
  valid packages are: 'IOS-DFU-Library'
```

## Cause

In `darwin/nordic_dfu/Package.swift`, the target references the product with `package: "NordicDFU"`, but the package identity SPM derives from the dependency URL (`https://github.com/NordicSemiconductor/IOS-DFU-Library.git`) is `IOS-DFU-Library`. The `package:` argument must match that identity, not the product name.

## Fix

```diff
-                .product(name: "NordicDFU", package: "NordicDFU")],
+                .product(name: "NordicDFU", package: "IOS-DFU-Library")],
```

The product name (`NordicDFU`) is unchanged; only the package identity is corrected.

## Verification

With this change, `flutter build ios` resolves SPM dependencies and builds successfully (verified on a real iOS app using SPM, Flutter 3.44, nordic_dfu 7.1.2).