### PR TITLE
fix(docs): Fix broken README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ The Nordic DFU library now includes an address mapping feature to track devices 
 
 ## Resources
 
--   [DFU Introduction](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v11.0.0/examples_ble_dfu.html?cp=6_0_0_4_3_1 "BLE Bootloader/DFU")
--   [Secure DFU Introduction](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v12.0.0/ble_sdk_app_dfu_bootloader.html?cp=4_0_0_4_3_1 "BLE Secure DFU Bootloader")
--   [How to create init packet](https://github.com/NordicSemiconductor/Android-nRF-Connect/tree/master/init%20packet%20handling "Init packet handling")
+-   [DFU Introduction](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/dfu.html "BLE Bootloader/DFU")
+-   [Secure DFU Introduction](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/bootloaders_dfu/mcuboot_nsib/bootloader.html "BLE Secure DFU Bootloader")
+-   [How to create init packet](https://github.com/NordicSemiconductor/Android-nRF-Connect/tree/main/init%20packet%20handling "Init packet handling")
 -   [nRF51 Development Kit (DK)](https://www.nordicsemi.com/eng/Products/nRF51-DK "nRF51 DK") (compatible with Arduino Uno Revision 3)
 -   [nRF52 Development Kit (DK)](https://www.nordicsemi.com/eng/Products/Bluetooth-Smart-Bluetooth-low-energy/nRF52-DK "nRF52 DK") (compatible with Arduino Uno Revision 3)
 


### PR DESCRIPTION
This updates the Nordic links. Currently both go to a page not found. I updated the links to what made sense based on the description.  Also adjusted the "How to create init packet" link since the master branch got renamed to main.