### PR TITLE
feat(android)!: stop declaring bluetooth permissions in plugin manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ event is reported with the address you passed to `startDfu`, on every platform, 
 
 `setAddressMapping`, `getTranslatedAddress`, `removeAddressMapping` and `clearAddressMappings` are
 therefore deprecated and will be removed in a future release. Delete your calls to them, along with any
-bootloader scanning that existed only to feed them — no replacement is needed.
+bootloader scanning that existed only to feed them, no replacement is needed.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,56 @@ await NordicDfu().startDfu(
          );
 ```
 
+## Android permissions
+
+From version 8.0.0 this plugin no longer declares Bluetooth permissions in its own
+`AndroidManifest.xml`, so your app decides which ones end up in the merged manifest. Add what your
+app actually needs to `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Required to scan for devices on API 31+. Add usesPermissionFlags="neverForLocation" when
+         you can strongly assert that your app never derives physical location from scan results;
+         the location permissions below are then not needed at all on API 31+. -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
+
+    <!-- Only required if you scan on API 30 and below, where scanning implies location access. -->
+    <uses-permission
+        android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
+</manifest>
+```
+
+Two things are still contributed for you and need no action:
+
+- `FOREGROUND_SERVICE` and `FOREGROUND_SERVICE_CONNECTED_DEVICE` come from this plugin, because the
+  DFU services it declares run as a foreground service unless you pass
+  `AndroidParameters(startAsForegroundService: false)`.
+- `BLUETOOTH` and `BLUETOOTH_ADMIN` (both `maxSdkVersion="30"`) and `BLUETOOTH_CONNECT` come from
+  the [Android-DFU-Library](https://github.com/NordicSemiconductor/Android-DFU-Library) itself.
+
+To change or drop one of the permissions supplied by the DFU library, override it with
+`tools:node="remove"` or `tools:node="replace"`:
+
+```xml
+<uses-permission
+    android:name="android.permission.BLUETOOTH_ADMIN"
+    tools:node="remove" />
+```
+
+### Upgrading from 7.x
+
+Previously the plugin declared `BLUETOOTH_SCAN`, `ACCESS_FINE_LOCATION` and
+`ACCESS_COARSE_LOCATION` (the last two via `uses-permission-sdk-23`, so on every API level from 23
+up). If your app relies on those and does not declare them itself, add them as shown above, or
+scanning stops working after upgrading. Apps that were fighting the old declarations with
+`tools:maxSdkVersion` or `tools:node="remove"` can delete those workarounds.
+
 ## Parallel DFU
 
 Available from version 7.0.0

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,26 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!-- required for API 18 - 30 -->
-    <uses-permission
-        android:name="android.permission.BLUETOOTH"
-        android:maxSdkVersion="30" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_ADMIN"
-        android:maxSdkVersion="30" />
+    <!-- Bluetooth permissions are intentionally NOT declared here, so apps stay in control of
+         their own merged manifest. Declare the ones you need yourself; see the "Android
+         permissions" section of the README.
 
-    <!-- required for API 23 - 33 -->
-    <uses-permission-sdk-23
-        android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <uses-permission-sdk-23
-        android:name="android.permission.ACCESS_FINE_LOCATION"/>
+         Note that BLUETOOTH, BLUETOOTH_ADMIN (both maxSdkVersion="30") and BLUETOOTH_CONNECT are
+         declared by the Android-DFU-Library this plugin depends on, and are merged into your app
+         from there.
 
-    <!-- API 31+ -->
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <!-- add android:usesPermissionFlags="neverForLocation" when you can strongly assert that
-         your app never derives physical location from Bluetooth scan results. -->
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+         The two permissions below are required by the DFU services declared in this manifest,
+         which run as a foreground service by default, so they stay here. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
 
     <application>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,26 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- The INTERNET permission is required for development. Specifically,
          flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- Bluetooth permissions are declared by the app, not by the plugin. This example scans for
+         devices, so it needs BLUETOOTH_SCAN on API 31+ and the location permissions that scanning
+         requires on API 30 and below. It never derives location from scan results, so
+         neverForLocation is asserted and no location permission is needed on API 31+. -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
+    <uses-permission
+        android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.ACCESS_COARSE_LOCATION"
+        android:maxSdkVersion="30" />
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.


### PR DESCRIPTION
Closes #163

## Problem

The plugin declared `BLUETOOTH_SCAN`, `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION` in its own manifest, the last two via `uses-permission-sdk-23` so on every API level from 23 up. Apps could not assert `neverForLocation` or cap the location permissions with `tools:maxSdkVersion` without Play Console rejecting the upload:

```
Duplicate declarations of permission android.permission.ACCESS_FINE_LOCATION with different maxSdkVersions
```

## Change

Bluetooth permissions are the app's call, so they are gone from the plugin manifest.

Two things are still contributed, deliberately:

* `FOREGROUND_SERVICE` and `FOREGROUND_SERVICE_CONNECTED_DEVICE` stay, because the `DfuService*` classes declared in this manifest run as a foreground service unless the app passes `startAsForegroundService: false`. Dropping them would be a `SecurityException` on API 34+ for everyone.
* `BLUETOOTH`, `BLUETOOTH_ADMIN` (both `maxSdkVersion="30"`) and `BLUETOOTH_CONNECT` come from the Android-DFU-Library's own manifest and merge in from there regardless. The library deliberately omits `BLUETOOTH_SCAN` and location, so the permissions this issue is about were ours alone.

The example app had no BLE permissions of its own and was living off the plugin's, so it now declares its own. The README documents what apps need to add, what is still supplied for them, and how to override the library's declarations.

## Verification

Built the example APK and dumped the merged manifest:

```
uses-permission: name='android.permission.BLUETOOTH_SCAN' usesPermissionFlags='neverForLocation'
uses-permission: name='android.permission.ACCESS_FINE_LOCATION' maxSdkVersion='30'
uses-permission: name='android.permission.ACCESS_COARSE_LOCATION' maxSdkVersion='30'
uses-permission: name='android.permission.FOREGROUND_SERVICE'
uses-permission: name='android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE'
uses-permission: name='android.permission.BLUETOOTH' maxSdkVersion='30'
uses-permission: name='android.permission.BLUETOOTH_ADMIN' maxSdkVersion='30'
uses-permission: name='android.permission.BLUETOOTH_CONNECT'
```

`neverForLocation` survives the merge and location no longer leaks past API 30, which is what the issue asked for. The `tools:maxSdkVersion` workaround from the thread is no longer needed.

## Breaking change

Android apps must declare `BLUETOOTH_SCAN` and, if they scan on API 30 and below, `ACCESS_FINE_LOCATION` themselves. Apps relying on the plugin's declarations stop receiving scan results until they do. Commit is marked `feat!`, so release-please will cut 8.0.0.
