### PR TITLE
ci: group and cool down dependabot updates, verify the NordicDFU pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,31 @@
 version: 2
+
+# Applies to every ecosystem below.
+#
+# A "<type>(scope): ..." prefix is required, otherwise semantic-pr.yml rejects
+# Dependabot's default "Bump x from y to z" titles.
+#
+# Ecosystems that ship to plugin consumers (the plugin's own Android/Swift/pub
+# dependencies) use "deps", which release-please renders under a "Dependencies"
+# changelog heading. Dev-only ecosystems (CI actions, the example app) use
+# "chore" so they stay out of the changelog. Reviewers are not listed: CODEOWNERS
+# already requests review on everything, and the key is deprecated.
+#
+# The cooldown lets a release settle before it is proposed, so that a version
+# superseded within days never costs a PR. Security updates ignore it.
+
 updates:
-  # A "<type>(scope): ..." prefix is required on every ecosystem here, otherwise
-  # semantic-pr.yml rejects Dependabot's default "Bump x from y to z" titles.
-  #
-  # Ecosystems that ship to plugin consumers (the plugin's own Android/Swift/pub
-  # dependencies) use "deps", which release-please renders under a
-  # "Dependencies" changelog heading. Dev-only ecosystems (CI actions, the
-  # example app) use "chore" so they stay out of the changelog.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-    reviewers:
-      - juliansteenbakker
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: chore
       include: scope
@@ -21,51 +34,65 @@ updates:
     directory: /android
     schedule:
       interval: weekly
-    reviewers:
-      - juliansteenbakker
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     commit-message:
       prefix: deps
-      include: scope
 
   - package-ecosystem: gradle
     directory: /example/android
     schedule:
       interval: weekly
-    reviewers:
-      - juliansteenbakker
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      example-android:
+        patterns:
+          - "*"
     commit-message:
       prefix: chore
       include: scope
 
+  # prefix-development keeps a bump of a dev_dependency, which no consumer of
+  # the package resolves, out of the "Dependencies" changelog section.
   - package-ecosystem: pub
     directory: /
     schedule:
       interval: weekly
-    reviewers:
-      - juliansteenbakker
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     commit-message:
       prefix: deps
-      include: scope
+      prefix-development: chore
 
   - package-ecosystem: pub
     directory: /example
     schedule:
       interval: weekly
-    reviewers:
-      - juliansteenbakker
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      example-dart:
+        patterns:
+          - "*"
     commit-message:
       prefix: chore
       include: scope
 
   # Directory must hold Package.swift. Note that the CocoaPods pin on
   # NordicDFU in darwin/nordic_dfu.podspec is not covered: Dependabot has no
-  # CocoaPods support, so that one has to be bumped by hand to match.
+  # CocoaPods support, so that one has to be bumped by hand to match. The
+  # "Darwin Dependency Pin" job in ci.yml fails the build until it is.
   - package-ecosystem: swift
     directory: /darwin/nordic_dfu
     schedule:
       interval: weekly
-    reviewers:
-      - juliansteenbakker
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     commit-message:
       prefix: deps
-      include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,33 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v5
 
+  darwin_dependency_pin:
+    name: Darwin Dependency Pin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      # Dependabot updates Package.swift but has no CocoaPods support, so the
+      # podspec pin is bumped by hand and silently drifts otherwise. The two
+      # constraints are equivalent by construction: `~> 4.17.0` and
+      # `.upToNextMinor(from: "4.17.0")` both allow 4.17.x, so comparing the
+      # versions they name is enough.
+      - name: Compare NordicDFU Pins
+        run: |
+          spm=$(grep -o 'upToNextMinor(from: "[0-9][0-9.]*"' darwin/nordic_dfu/Package.swift | grep -o '[0-9][0-9.]*')
+          pod=$(grep -o "s.dependency 'NordicDFU', '~> [0-9][0-9.]*'" darwin/nordic_dfu.podspec | grep -o '[0-9][0-9.]*')
+          echo "Package.swift: ${spm:-<not found>}"
+          echo "podspec:       ${pod:-<not found>}"
+          if [ -z "$spm" ] || [ -z "$pod" ]; then
+            echo "::error::Could not read the NordicDFU version from both files."
+            exit 1
+          fi
+          if [ "$spm" != "$pod" ]; then
+            echo "::error::NordicDFU pins differ. Bump darwin/nordic_dfu.podspec to $spm."
+            exit 1
+          fi
+
   analysis:
     name: Analysis (${{ matrix.name }})
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ unlinked_spec.ds
 **/ios/**/Pods/
 **/ios/**/.symlinks/
 **/ios/**/profile
+**/ios/**/xcshareddata/swiftpm/
 **/ios/**/xcuserdata
 **/ios/.generated/
 **/ios/Flutter/.last_build_id
@@ -102,6 +103,7 @@ unlinked_spec.ds
 
 # macOS
 **/macos/Flutter/GeneratedPluginRegistrant.swift
+**/macos/**/xcshareddata/swiftpm/
 
 # Coverage
 coverage/

--- a/darwin/.gitignore
+++ b/darwin/.gitignore
@@ -34,3 +34,9 @@ Icon?
 .tags*
 
 /Flutter/Generated.xcconfig
+
+# Swift Package Manager. Package.resolved is deliberately not committed: this is
+# a library, so the resolved versions come from the app that consumes it.
+.build/
+.swiftpm/
+Package.resolved


### PR DESCRIPTION
## Description

Dependabot coverage was already complete, this is cleanup of how the updates arrive.

- Dev-only ecosystems (actions, example app) are grouped into one PR each, and everything gets a 7 day cooldown (14 for majors), so a version superseded within the week no longer costs two PRs like the recent AGP 9.3.1/9.3.2/9.4.0 round did.
- The `deps` entries lose `include: scope`, which was producing `deps(deps): ...` titles.
- The root pubspec gets `prefix-development: chore` so a `very_good_analysis` bump stays out of the Dependencies section of the changelog.
- `reviewers` is gone everywhere, CODEOWNERS already covers it and the key is deprecated.

The new Darwin Dependency Pin job compares the NordicDFU version in `Package.swift` against the `~>` pin in the podspec. Dependabot has no CocoaPods support, so that pin is bumped by hand and nothing was checking it. The two constraint forms allow the same range, so comparing the versions they name is enough.

Also ignoring the SwiftPM state that the Swift updates leave behind locally: `.build/`, `.swiftpm/` and `Package.resolved` under `darwin/`, plus the example app's generated `xcshareddata/swiftpm/` on iOS and macOS. None of it is worth committing, a library's resolved versions come from the app consuming it, and pinning the example app would work against the CI jobs that exist to prove the plugin still builds against current versions.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.