### PR TITLE
ci: drop semver-major-days from the dependabot cooldowns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       github-actions:
         patterns:
@@ -36,7 +35,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     commit-message:
       prefix: deps
 
@@ -46,7 +44,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       example-android:
         patterns:
@@ -63,7 +60,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     commit-message:
       prefix: deps
       prefix-development: chore
@@ -74,7 +70,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       example-dart:
         patterns:
@@ -93,6 +88,5 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-      semver-major-days: 14
     commit-message:
       prefix: deps


### PR DESCRIPTION
## Description

#306 broke the config. Dependabot rejects `semver-major-days` for the `github-actions` ecosystem, and a parse error takes the whole file down, so no updates are running on develop right now.

The option is only accepted for ecosystems whose versions Dependabot classifies as semver. Rather than keep it on the four entries where it might be allowed and have the file differ per ecosystem for non-obvious reasons, every entry now uses `default-days: 7` alone. The churn suppression that was the point of the cooldown is unaffected, majors just no longer get a longer window.

Same fix is in flutter_ble_central#129 and flutter_ble_peripheral#317, which had not been merged yet.

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.