### PR TITLE
fix(darwin): apply numberOfPackets when no Darwin PRN is set

### DIFF
--- a/darwin/nordic_dfu/Sources/nordic_dfu/Classes/NordicDfuPlugin.swift
+++ b/darwin/nordic_dfu/Sources/nordic_dfu/Classes/NordicDfuPlugin.swift
@@ -256,7 +256,10 @@ private struct DfuOptions {
 
     init(arguments: [String: Any]) {
         self.name = arguments["name"] as? String
+        // The top-level `numberOfPackets` argument is platform-neutral, so fall
+        // back to it when DarwinParameters does not set a PRN of its own.
         self.packetReceiptNotificationParameter = arguments["packetReceiptNotificationParameter"] as? UInt16
+            ?? arguments["numberOfPackets"] as? UInt16
         self.forceDfu = arguments["forceDfu"] as? Bool
         self.forceScanningForNewAddressInLegacyDfu = arguments["forceScanningForNewAddressInLegacyDfu"] as? Bool
         self.connectionTimeout = arguments["connectionTimeout"] as? TimeInterval


### PR DESCRIPTION
## Description

The top-level `numberOfPackets` argument never reached the Darwin plugin, which only read `packetReceiptNotificationParameter` from `DarwinParameters`. The value was dropped without a warning and the transfer ran at the library default PRN of 12, which breaks targets that cannot take it (reported in #309 for the Adafruit nRF52 bootloader).

The Darwin side now falls back to `numberOfPackets` when `DarwinParameters` does not set a PRN, so the platform-neutral parameter behaves like its position suggests.

Fixes #309

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.