### PR TITLE
feat(android): expose disableMtuRequest on AndroidParameters

### DIFF
--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuConfig.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/DfuConfig.kt
@@ -20,5 +20,6 @@ data class DfuConfig(
     val rebootTime: Long?,
     val mbrSize: Int?,
     val scope: Int?,
-    val currentMtu: Int?
+    val currentMtu: Int?,
+    val disableMtuRequest: Boolean?
 )

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfu.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfu.kt
@@ -112,6 +112,9 @@ class NordicDfu(private val context: Context, private val callback: DfuCallback)
         config.currentMtu?.let {
             starter.setCurrentMtu(it)
         }
+        if (config.disableMtuRequest == true) {
+            starter.disableMtuRequest()
+        }
 
         warnAboutAdjacentAddress(config.address)
 

--- a/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfuPlugin.kt
+++ b/android/src/main/kotlin/dev/steenbakker/nordicdfu/NordicDfuPlugin.kt
@@ -91,6 +91,7 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
         val mbrSize = call.argument<Int>("mbrSize")
         val scope = call.argument<Int>("scope")
         val currentMtu = call.argument<Int>("currentMtu")
+        val disableMtuRequest = call.argument<Boolean>("disableMtuRequest")
 
         if (fileInAsset == null) fileInAsset = false
         if (address == null || filePath == null) {
@@ -137,7 +138,8 @@ class NordicDfuPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHan
             rebootTime = rebootTime,
             mbrSize = mbrSize,
             scope = scope,
-            currentMtu = currentMtu
+            currentMtu = currentMtu,
+            disableMtuRequest = disableMtuRequest
         )
 
         // Store pending result for this address

--- a/lib/src/parameters/android_parameters.dart
+++ b/lib/src/parameters/android_parameters.dart
@@ -14,6 +14,7 @@ class AndroidParameters {
     this.mbrSize,
     this.scope,
     this.currentMtu,
+    this.disableMtuRequest,
   });
 
   ///Sets whether the progress notification in the status bar should be disabled.
@@ -101,6 +102,14 @@ class AndroidParameters {
   /// This can optimize the DFU transfer speed based on the negotiated MTU.
   final int? currentMtu;
 
+  /// Disables requesting a higher MTU, keeping the link at the default size.
+  ///
+  /// Needed for targets that grant a large MTU but declare a smaller DFU packet
+  /// characteristic, such as Legacy DFU with its 20 byte limit. Their writes are
+  /// rejected at the ATT layer, and since data packets are sent without
+  /// response, the transfer stalls without reporting an error.
+  final bool? disableMtuRequest;
+
   /// Converts AndroidParameters into a json object.
   Map<String, dynamic> toJson() => {
         'disableNotification': disableNotification,
@@ -114,5 +123,6 @@ class AndroidParameters {
         'mbrSize': mbrSize,
         'scope': scope,
         'currentMtu': currentMtu,
+        'disableMtuRequest': disableMtuRequest,
       };
 }


### PR DESCRIPTION
## Description

`AndroidParameters` only exposed `currentMtu`, which declares an already negotiated MTU and does not stop the library from requesting a larger one. Targets that grant a large MTU but declare a smaller DFU packet characteristic, such as Legacy DFU with its 20 byte limit, then get writes rejected at the ATT layer. Data packets are sent without response, so the transfer stalls at the first packet with no error and no disconnect (reported in #310).

Adds a `disableMtuRequest` flag that calls `DfuServiceInitiator.disableMtuRequest()`, threaded through the plugin and `DfuConfig` like the other Android options.

Fixes #310

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.